### PR TITLE
Add version to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Build stage
 FROM maven:3-jdk-11 as build
+ARG commit_sha
+ENV COMMIT_SHA=$commit_sha
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends nodejs
 WORKDIR /usr/src/app/
 COPY src src
 COPY frontend frontend
 COPY pom.xml .
+RUN echo "$COMMIT_SHA" > src/main/resources/META-INF/resources/version.txt
 RUN mvn clean package -DskipTests -Pproduction
 
 # Run stage


### PR DESCRIPTION
- Image is built with `docker build --build-arg commit_sha=${GIT_COMMIT}`
- Value is available to other commands through the environment variable `COMMIT_SHA` 
- File `version.txt` containing the commit is created in `src/main/resources/META-INF/resources` 
- When the application runs, the version is available in "$URL/version.txt"