### PR TITLE
fix: bind also happiness radiobuttons to the bean

### DIFF
--- a/src/main/java/com/jensjansson/ce/views/persons/EditorView.java
+++ b/src/main/java/com/jensjansson/ce/views/persons/EditorView.java
@@ -181,7 +181,6 @@ public class EditorView extends Div {
         happiness.setLabel("How excited are they?");
         happiness.setItems(HAPPINESS_VALUES);
         happiness.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
-        happiness.setValue("Raptorous");
 
         // Configure Form
         binder = new CollaborationBinder<>(Person.class, localUser);
@@ -192,6 +191,7 @@ public class EditorView extends Div {
         binder.forField(title).bind("title");
         binder.forField(department).bind("department");
         binder.forField(team).bind("team");
+        binder.forField(happiness).bind("happiness");
 
         // Bind fields. This where you'd define e.g. validation rules
         binder.bindInstanceFields(this);


### PR DESCRIPTION
## Description

There is a Person form in the demo, that should demonstrate the cooperation of collaborating users. All the fields in the form are bound to the ColloaborationBinder and therefore they show when some other user edited the field. With the exception of the "How excited are they?" radiobuttons - they are not bound to the binder and therefore changes to it will not be displayed to other users.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/868cd226-45f5-439d-9863-97e8ec5167ba">

This is weird and unexpected.

This PR fixes the issue by binding also the radio buttons, so the form is completely synced between users.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.