### PR TITLE
Remove commons-io exclusion that breaks startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,6 @@
             <groupId>org.vaadin.artur.exampledata</groupId>
             <artifactId>exampledata</artifactId>
             <version>1.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Remove the `commons-io` exclusion from the `exampledata` dependency
- With Spring Boot 4.x, `commons-io` is no longer available transitively, causing `NoClassDefFoundError: org/apache/commons/io/IOUtils` at startup when generating demo data

## Test plan
- [x] `mvn compile` succeeds
- [x] Application starts and generates 100 Person entities without errors

Fixes #154